### PR TITLE
Update gem and remove instance variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby "2.3.1"
 
 gem 'rails', '4.2.6'
 gem 'rails-api'
-gem 'locations_ng', '0.0.5'
+gem 'locations_ng', '>= 1.0.0'
 gem 'rack-cors', require: 'rack/cors'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     json (1.8.3)
-    locations_ng (0.0.5)
+    locations_ng (1.0.0)
       rails (= 4.2.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -119,7 +119,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  locations_ng (= 0.0.5)
+  locations_ng (>= 1.0.0)
   pg
   pry-rails
   rack-cors

--- a/app/controllers/api/v1/cities_controller.rb
+++ b/app/controllers/api/v1/cities_controller.rb
@@ -2,9 +2,7 @@ module Api
   module V1 
     class CitiesController < ApplicationController
       def index 
-        @cities = LocationsNg::City.all
-
-        render json: @cities
+        render json: LocationsNg::City.all
       end 
     end 
   end 

--- a/app/controllers/api/v1/cities_controller.rb
+++ b/app/controllers/api/v1/cities_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1 
     class CitiesController < ApplicationController
       def index 
-        @cities = LocationsNg::City.new.all
+        @cities = LocationsNg::City.all
 
         render json: @cities
       end 

--- a/app/controllers/api/v1/lgas_controller.rb
+++ b/app/controllers/api/v1/lgas_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1 
     class LgasController < ApplicationController
       def index 
-        @lgas = LocationsNg::Lga.new.all
+        @lgas = LocationsNg::Lga.all
 
         render json: @lgas 
       end 

--- a/app/controllers/api/v1/lgas_controller.rb
+++ b/app/controllers/api/v1/lgas_controller.rb
@@ -1,10 +1,8 @@
 module Api 
   module V1 
     class LgasController < ApplicationController
-      def index 
-        @lgas = LocationsNg::Lga.all
-
-        render json: @lgas 
+      def index
+        render json: LocationsNg::Lga.all
       end 
     end 
   end 

--- a/app/controllers/api/v1/states_controller.rb
+++ b/app/controllers/api/v1/states_controller.rb
@@ -29,7 +29,7 @@ module Api
       private 
 
       def set_ng_state 
-        @ng_state =  LocationsNg::State.new 
+        @ng_state =  LocationsNg::State
       end 
 
       def state_params 

--- a/app/controllers/api/v1/states_controller.rb
+++ b/app/controllers/api/v1/states_controller.rb
@@ -1,35 +1,30 @@
 module Api 
   module V1 
     class StatesController < ApplicationController
-      before_action :set_ng_state, only: [:index, :details, :capital]
       def index 
-        render json: @ng_state.all
+        render json: set_ng_state.all
       end 
 
       def details 
-        render json: @ng_state.details(params[:state])
+        render json: set_ng_state.details(params[:state])
       end 
 
       def capital 
-        render json: @ng_state.capital(params[:state])
+        render json: set_ng_state.capital(params[:state])
       end 
 
-      def cities 
-        @state_cities = LocationsNg::City.new.cities(params[:state])
-
-        render json: @state_cities
+      def cities
+        render json: LocationsNg::City.cities(params[:state])
       end 
 
       def lgas 
-        @state_lgas = LocationsNg::Lga.new.lgas(params[:state])
-
-        render json: @state_lgas
+        render json: LocationsNg::Lga.lgas(params[:state])
       end 
 
       private 
 
       def set_ng_state 
-        @ng_state =  LocationsNg::State
+        LocationsNg::State
       end 
 
       def state_params 


### PR DESCRIPTION
Versions >= 1.0.0 makes use of class methods, and thus easier to query.
I removed the instance variables in the controller because it's an API and not necessary.
